### PR TITLE
Use Data.Text.Text as input.

### DIFF
--- a/test/Data/Argonaut/ParserSpec.hs
+++ b/test/Data/Argonaut/ParserSpec.hs
@@ -4,6 +4,7 @@ module Data.Argonaut.ParserSpec where
 
 import Data.Argonaut.Parser
 import Data.Argonaut.TestInstances()
+import qualified Data.Text as T
 import Test.Hspec
 import Test.QuickCheck
 
@@ -13,6 +14,6 @@ spec = do
     it "for some valid json, produces the same value" $ do
       property $ \originalJson ->
         let
-          asString = show originalJson
+          asString = T.pack $ show originalJson
           parsedJson = parseString asString
         in parsedJson `shouldBe` (StringErrorParseSuccess originalJson)

--- a/test/Data/Argonaut/TestInstances.hs
+++ b/test/Data/Argonaut/TestInstances.hs
@@ -3,8 +3,10 @@
 
 module Data.Argonaut.TestInstances where
 
+import Control.Applicative
 import Control.Monad
 import Data.Argonaut
+import Data.Text (Text, pack)
 import Test.QuickCheck
 import qualified Data.Vector as V
 import qualified Data.HashMap.Strict as M
@@ -20,6 +22,9 @@ instance Arbitrary JArray where
 
 instance Arbitrary JObject where
   arbitrary = liftM (JObject . M.fromList) arbitrary
+
+instance Arbitrary Text where
+    arbitrary = pack <$> (arbitrary :: Gen String)
 
 genJsonObject :: Gen Json
 genJsonObject = liftM fromObject arbitrary


### PR DESCRIPTION
Hi Sean,

As per our quick discussion on IRC, this is the PR that changes the parser's input from `String` to `Data.Text.Text` and should serve as a basis for discussion. You mentioned that the design of the scala version has changed since the inception of `argonaut-hs`, so feel free to ignore this. ;)

I'm making heavy use of _view patterns_ for matching prefixes. Not sure if this impacts performance and it'd be better to check non-emptiness and getting the characters via `head`.

Cheers
