### PR TITLE
Adding Applicative, Apply, and Bind instances to ParseResult

### DIFF
--- a/argonaut.cabal
+++ b/argonaut.cabal
@@ -34,7 +34,8 @@ library
                                     template-haskell >= 2.8.0.0,
                                     bytestring >= 0.10.4.0,
                                     hashable >= 1.2.1.0,
-                                    scientific >= 0.2.0.2
+                                    scientific >= 0.2.0.2,
+                                    semigroupoids >= 4.3
     ghc-options:                    -rtsopts
                                     -Wall
                                     -O2

--- a/src/Data/Argonaut/Parser.hs
+++ b/src/Data/Argonaut/Parser.hs
@@ -39,12 +39,11 @@ import qualified Data.HashMap.Strict as M
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Data.Argonaut.Templates()
-import qualified Data.Attoparsec.ByteString as AB
-import qualified Data.Attoparsec as A
-import qualified Data.Attoparsec.Lazy as L
+import qualified Data.Attoparsec.ByteString as A
+import qualified Data.Attoparsec.ByteString.Lazy as L
 import qualified Data.Attoparsec.Zepto as Z
 import Control.Applicative ((*>), (<$>), (<*), liftA2, pure)
-import qualified Data.Attoparsec.Char8 as AC
+import qualified Data.Attoparsec.ByteString.Char8 as AC
 
 #define BACKSLASH 92
 #define CLOSE_CURLY 125
@@ -100,7 +99,7 @@ parseText :: T.Text -> ParseResult Json
 parseText = parseByteString . TE.encodeUtf8
 
 parseByteString :: B.ByteString -> ParseResult Json
-parseByteString bytestring = case AB.parseOnly jsonValidSuffixParser bytestring of
+parseByteString bytestring = case A.parseOnly jsonValidSuffixParser bytestring of
   Left failMessage      -> ParseFailure failMessage
   Right result          -> ParseSuccess result
 

--- a/src/Data/Argonaut/Parser.hs
+++ b/src/Data/Argonaut/Parser.hs
@@ -33,6 +33,9 @@ import qualified Data.ByteString.Lazy as LB
 import qualified Data.ByteString.Builder as BSB
 import Data.Argonaut.Core
 import Data.Argonaut.Printer
+import Data.Functor.Apply (Apply(..))
+import Data.Functor.Bind (Bind(..))
+import Control.Applicative (Applicative(..), (*>), (<$>), (<*), liftA2, pure)
 import Control.Lens
 import qualified Data.Vector as V
 import qualified Data.HashMap.Strict as M
@@ -42,7 +45,6 @@ import Data.Argonaut.Templates()
 import qualified Data.Attoparsec.ByteString as A
 import qualified Data.Attoparsec.ByteString.Lazy as L
 import qualified Data.Attoparsec.Zepto as Z
-import Control.Applicative ((*>), (<$>), (<*), liftA2, pure)
 import qualified Data.Attoparsec.ByteString.Char8 as AC
 
 #define BACKSLASH 92
@@ -72,6 +74,18 @@ data ParseResult a = ParseFailure !String | ParseSuccess !a deriving (Eq, Show)
 instance Functor ParseResult where
   fmap _ (ParseFailure x)  = ParseFailure x
   fmap f (ParseSuccess y)  = ParseSuccess (f y)
+
+instance Apply ParseResult where
+  (<.>) = (<*>)
+
+instance Applicative ParseResult where
+  pure = ParseSuccess
+  ParseFailure l <*> _              = ParseFailure l
+  _              <*> ParseFailure l = ParseFailure l
+  ParseSuccess f <*> ParseSuccess r = ParseSuccess (f r)
+
+instance Bind ParseResult where
+  (>>-) = (>>=)
 
 instance Monad ParseResult where
   return = ParseSuccess


### PR DESCRIPTION
ParseResult needed an Applicative instance to comply with AMP. Apply and Bind instances are also appropriate.
Semigroupoids, which provides Apply and Bind, was already lurking around due to the Lens dependency. I just had to let argonaut.cabal know about it.
